### PR TITLE
Prevent a high number from turning into scientific notation

### DIFF
--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -1,6 +1,7 @@
 local resty_http = require "resty.http"
 local to_hex = require "resty.string".to_hex
-local cjson = require "cjson"
+local cjson = require "cjson".new()
+cjson.encode_number_precision(16)
 
 local zipkin_reporter_methods = {}
 local zipkin_reporter_mt = {


### PR DESCRIPTION
e.g. 1530160440770000 => 1.53016044077e+15
The scientific notation cannot be correctly handled by Jaeger OpenTracing server. And the error message from Jaeger server is "Unable to process request body: json: cannot unmarshal number 1.53016044077e+15 into Go struct field Span.timestamp of type int64".