### PR TITLE
feat(zipkin) update to new db

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,3 +2,6 @@ std = "ngx_lua"
 files["spec"] = {
 	std = "+busted";
 }
+globals = {
+	"kong",
+}

--- a/kong/plugins/zipkin/codec.lua
+++ b/kong/plugins/zipkin/codec.lua
@@ -84,7 +84,7 @@ local function new_injector()
 		headers["x-b3-traceid"] = to_hex(span_context.trace_id)
 		headers["x-b3-parentspanid"] = span_context.parent_id and to_hex(span_context.parent_id) or nil
 		headers["x-b3-spanid"] = to_hex(span_context.span_id)
-		local Flags = ngx.req.get_headers()["x-b3-flags"] -- Get from request headers
+		local Flags = kong.request.get_header("x-b3-flags") -- Get from request headers
 		headers["x-b3-flags"] = Flags
 		headers["x-b3-sampled"] = (not Flags) and (span_context.should_sample and "1" or "0") or nil
 		for key, value in span_context:each_baggage_item() do

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -1,14 +1,16 @@
-local Errors = require "kong.dao.errors"
+local typedefs = require "kong.db.schema.typedefs"
 
 return {
+	name = "zipkin",
 	fields = {
-		http_endpoint = { required = true, type = "url" },
-		sample_ratio = { default = 0.001, type = "number" },
+		{ config = {
+				type = "record",
+				fields = {
+					{ http_endpoint = typedefs.url{ required = true } },
+					{ sample_ratio = { type = "number",
+					                   default = 0.001,
+					                   between = { 0, 1 } } },
+				},
+		}, },
 	},
-	self_check = function(schema, plugin, dao, is_updating) -- luacheck: ignore 212
-		if plugin.sample_ratio and (plugin.sample_ratio < 0 or plugin.sample_ratio > 1) then
-			return false, Errors.schema "sample_ratio must be between 0 and 1"
-		end
-		return true
-	end
 }


### PR DESCRIPTION
This PR updates the zipkin plugin to the latest (`next`) branch in Kong by doing the following changes:

* Updated `kong/plugins/zipkin/schema.lua` to the new schema.lua syntax
* All calls to `ngx.req` have been replaced with `kong.request`.
* Calls to `ngx.log` are now `kong.log`
* Use `kong.client.get_port` instead of `ngx.var.remote_port`
* `public.node.get_id` becomes `kong.node.get_id`

We still use `nxg` in a couple places:
* to get the request start time: ngx.req.start_time()
* to use the context: ngx.ctx. The usage this plugin does is not currently covered by the PDK's `kong.ctx` abstraction.


