### PR TITLE
feat(zipkin) override unknown-service-name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Kong Inc.
+   Copyright 2018-2019 Kong Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-UNRELEASED
+0.1.2 - 2019-01-18
 
   - Fix logging failure when DNS is not resolved
   - Avoid sending redundant tags (#28)

--- a/kong-plugin-zipkin-0.1.2-0.rockspec
+++ b/kong-plugin-zipkin-0.1.2-0.rockspec
@@ -1,8 +1,9 @@
 package = "kong-plugin-zipkin"
-version = "scm-0"
+version = "0.1.2-0"
 
 source = {
-	url = "git+https://github.com/kong/kong-plugin-zipkin.git";
+	url = "https://github.com/kong/kong-plugin-zipkin/archive/v0.1.2.zip";
+	dir = "kong-plugin-zipkin-0.1.2";
 }
 
 description = {
@@ -15,8 +16,7 @@ dependencies = {
 	"lua >= 5.1";
 	"lua-cjson";
 	"lua-resty-http >= 0.11";
-	"kong >= 0.15";
-	"opentracing >= 0.0.2";
+	"opentracing == 0.0.2";
 }
 
 build = {

--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -11,7 +11,7 @@ local BasePlugin = require "kong.plugins.base_plugin"
 local subsystem = ngx.config.subsystem
 
 local OpenTracingHandler = BasePlugin:extend()
-OpenTracingHandler.VERSION = "scm"
+OpenTracingHandler.VERSION = "0.1.2"
 
 -- We want to run first so that timestamps taken are at start of the phase
 -- also so that other plugins might be able to use our structures

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -11,8 +11,10 @@ local zipkin_reporter_mt = {
 
 local function new_zipkin_reporter(conf)
 	local http_endpoint = conf.http_endpoint
+	local default_service_name = conf.default_service_name
 	assert(type(http_endpoint) == "string", "invalid http endpoint")
 	return setmetatable({
+	        default_service_name = default_service_name;
 		http_endpoint = http_endpoint;
 		pending_spans = {};
 		pending_spans_n = 0;
@@ -48,8 +50,15 @@ function zipkin_reporter_methods:report(span)
 				-- TODO: ip/port from ngx.var.server_name/ngx.var.server_port?
 			}
 		else
-			-- needs to be null; not the empty object
-			localEndpoint = cjson.null
+		  -- configurable override of the unknown-service-name spans
+                  if self.default_service_name then
+	            localEndpoint = {
+                      serviceName = self.default_service_name;
+                    }
+		  -- needs to be null; not the empty object
+		  else
+		    localEndpoint = cjson.null
+		  end
 		end
 	end
 

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -11,6 +11,8 @@ return {
 					{ sample_ratio = { type = "number",
 					                   default = 0.001,
 					                   between = { 0, 1 } } },
+					{ default_service_name = { type = "string",
+					                        default = nil }, },
 				},
 		}, },
 	},


### PR DESCRIPTION
Optional configurable field to enable setting a defaulted service name in the zipkin spans to replace the unknown-service-name existing behavior,

Fixes: https://github.com/Kong/kong-plugin-zipkin/issues/39
Fixes: https://github.com/Kong/kong-plugin-zipkin/issues/23  (I think if I am reading it correctly)

I defaulted the string to nil as to not change any behavior of the plugin by default. Could easily set default to "Kong" if that is preferred but that would change default behavior so I didn't commit it like that. 