### PR TITLE
feat(zipkin) override unknown-service-name

### DIFF
--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -11,8 +11,10 @@ local zipkin_reporter_mt = {
 
 local function new_zipkin_reporter(conf)
 	local http_endpoint = conf.http_endpoint
+	local default_service_name = conf.default_service_name
 	assert(type(http_endpoint) == "string", "invalid http endpoint")
 	return setmetatable({
+                default_service_name = default_service_name;
 		http_endpoint = http_endpoint;
 		pending_spans = {};
 		pending_spans_n = 0;
@@ -48,8 +50,15 @@ function zipkin_reporter_methods:report(span)
 				-- TODO: ip/port from ngx.var.server_name/ngx.var.server_port?
 			}
 		else
-			-- needs to be null; not the empty object
-			localEndpoint = cjson.null
+                        -- configurable override of the unknown-service-name spans
+                        if self.default_service_name then
+                                localEndpoint = {
+                                        serviceName = self.default_service_name;
+                                }
+                        -- needs to be null; not the empty object
+                        else
+                                localEndpoint = cjson.null
+                        end
 		end
 	end
 

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -11,6 +11,7 @@ return {
 					{ sample_ratio = { type = "number",
 					                   default = 0.001,
 					                   between = { 0, 1 } } },
+                                        { default_service_name = { type = "string", default = nil } },
 					{ include_credential = { type = "boolean", required = true, default = true } },
 				},
 		}, },


### PR DESCRIPTION
Optional configurable field to enable setting a defaulted service name in the zipkin spans to replace the unknown-service-name existing behaviour,

Fixes: #39
Fixes: #23 (I think if I am reading it correctly)

I defaulted the string to nil as to not change any behaviour of the plugin by default. Could easily set default to "Kong" if that is preferred but that would change default behaviour so I didn't commit it like that.