### PR TITLE
fix(*) zipkin span fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,70 @@
-language: python
-
-sudo: false
+language: generic
+dist: trusty
+sudo: required
 
 branches:
   only:
     - master
 
-before_install:
-  - pip install hererocks
-  - hererocks ~/hererocks -r^ --luajit 2.1
-  - export PATH=$PATH:~/hererocks/bin
-  - eval $(luarocks path --bin)
-  - luarocks install luacheck
+services:
+  - redis-server
+
+addons:
+  postgresql: "9.5"
+  apt:
+    packages:
+      - net-tools
+      - libpcre3-dev
+      - build-essential
+
+services:
+  - redis
+  - docker
+
+env:
+  global:
+    - PLUGIN_NAME=zipkin
+    - KONG_REPOSITORY=kong
+    - KONG_TAG=master
+    - KONG_PLUGINS=bundled
+    - KONG_TEST_PLUGINS=$KONG_PLUGINS
+    - LUAROCKS=3.2.1
+    - OPENSSL=1.1.1d
+    - CASSANDRA_BASE=2.2.12
+    - CASSANDRA_LATEST=3.9
+    - OPENRESTY=1.15.8.2
+    - DOWNLOAD_CACHE=$HOME/download-cache
+    - INSTALL_CACHE=$HOME/install-cache
+    - BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
+    - TEST_FILE_PATH=$TRAVIS_BUILD_DIR/spec
+
+  matrix:
+    # Some of these might be commented off because they don't apply for the current plugin.
+    # If a plugin does not extend the pdk, the pdk test suite doesn't need to be run.
+    # If a plugin is not compatible with dbless, then the dbless test suite doesn't need to be run.
+    # If a plugin doesn't monkeypatch Kong's internal entities, it should not need to run integration tests
+    # - TEST_SUITE=pdk
+    # - KONG_TEST_DATABASE=postgres TEST_SUITE=integration
+    # - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_BASE TEST_SUITE=integration
+    # - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_LATEST TEST_SUITE=integration
+    # - KONG_TEST_DATABASE=off TEST_SUITE=dbless
+    - KONG_TEST_DATABASE=postgres TEST_SUITE=plugins
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_BASE TEST_SUITE=plugins
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_LATEST TEST_SUITE=plugins
+
+install:
+  - git clone --single-branch https://$GITHUB_TOKEN:@github.com/Kong/kong-ci ../kong-ci
+  - source ../kong-ci/setup_plugin_env.sh
 
 script:
-  - luacheck .
+  - eval $LUACHECK_CMD
+  - eval $BUSTED_CMD
 
 notifications:
-  email:
-    on_success: change
-    on_failure: always
+  email: false
 
 cache:
   directories:
-    - $HOME/.cache/hererocks
+    - $DOWNLOAD_CACHE
+    - $INSTALL_CACHE
+    - $HOME/.ccm/repository

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Of those, this plugin currently uses:
 
 In addition to the above standardised tags, this plugin also adds:
 
+  - `component` (sent to Zipkin as "lc", for "local component")
   - `kong.api` (deprecated)
   - `kong.consumer`
   - `kong.credential`

--- a/README.md
+++ b/README.md
@@ -26,15 +26,20 @@ A tracer is created with the "http_headers" formatter set to use the headers des
 
 ## Spans
 
-  - `kong.request`: encompasing the whole request in kong.
-    All other spans are children of this.
-  - `kong.rewrite`: encompassing the kong rewrite phase
-  - `kong.proxy`: encompassing kong's time as a proxy
-    - `kong.access`: encompassing the kong access phase
-    - `kong.balancer`: each balancer phase will have it's own span
-    - `kong.header_filter`: encompassing the kong header filter phase
-    - `kong.body_filter`: encompassing the kong body filter phase
-
+  - *Request span*: 1 per request. Encompasses the whole request in kong (kind: `SERVER`).
+    The proxy span and balancer spans are children of this span.
+    Contains logs/annotations for the `kong.rewrite` phase start and end
+  - *Proxy span*: 1 per request. Encompassing most of Kong's internal processing of a request (kind: `CLIENT`)
+    Contains logs/annotations for the rest start/end of the rest of the kong phases:
+    `kong.access`, `kong.header_filter`, `kong.body_filter`, `kong.preread`
+  - *Balancer span(s)*: 0 or more per request, each encompassing one balancer attempt (kind: `CLIENT`)
+    Contains tags specific to the load balancing:
+    - `kong.balancer.try`: a number indicating the attempt order
+    - `peer.ipv4`/`peer.ipv6` + `peer.port` for the balanced port
+    - `error`: true/false depending on whether the balancing could be done or not
+    - `http.status_code`: the http status code received, in case of error
+    - `kong.balancer.state`: an nginx-specific description of the error: `next`/`failed` for HTTP failures, `0` for stream failures.
+      Equivalent to `state_name` in [OpenResty's Balancer's `get_last_failure` function](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#get_last_failure).
 
 ## Tags
 
@@ -47,6 +52,7 @@ Of those, this plugin currently uses:
   - `http.method`
   - `http.status_code`
   - `http.url`
+  - `error`
   - `peer.ipv4`
   - `peer.ipv6`
   - `peer.port`
@@ -66,5 +72,21 @@ In addition to the above standardised tags, this plugin also adds:
   - `kong.route`
   - `kong.service`
   - `kong.balancer.try`
-  - `kong.balancer.state`: see [here](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#get_last_failure) for possible values
-  - `kong.balancer.code`
+  - `kong.balancer.state`
+
+## Logs / Annotations
+
+Logs (annotations in Zipkin) are used to encode the begin and end of every kong phase.
+
+  - `kong.rewrite`, `start` / `finish`, `<timestamp>`
+  - `kong.access`, `start` / `finish`, `<timestamp>`
+  - `kong.preread`, `start` / `finish`, `<timestamp>`
+  - `kong.header_filter`, `start` / `finish`, `<timestamp>`
+  - `kong.body_filter`, `start` / `finish`, `<timestamp>`
+
+They are transmitted to Zipkin as annotations where the `value` is the concatenation of the log name and the value.
+
+For example, the `kong.rewrite`, `start` log would be transmitted as:
+
+  - `{ "value" = "kong.rewrite.start", timestamp = <timestamp> }`
+

--- a/kong/plugins/zipkin/codec.lua
+++ b/kong/plugins/zipkin/codec.lua
@@ -1,9 +1,11 @@
 local to_hex = require "resty.string".to_hex
 local new_span_context = require "opentracing.span_context".new
 
+
 local function hex_to_char(c)
   return string.char(tonumber(c, 16))
 end
+
 
 local function from_hex(str)
   if str ~= nil then -- allow nil to pass through
@@ -11,6 +13,7 @@ local function from_hex(str)
   end
   return str
 end
+
 
 local function new_extractor(warn)
   return function(headers)
@@ -78,6 +81,7 @@ local function new_extractor(warn)
   end
 end
 
+
 local function new_injector()
   return function(span_context, headers)
     -- We want to remove headers if already present
@@ -94,7 +98,8 @@ local function new_injector()
   end
 end
 
+
 return {
-  new_extractor = new_extractor;
-  new_injector = new_injector;
+  new_extractor = new_extractor,
+  new_injector = new_injector,
 }

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -8,12 +8,14 @@ local OpenTracingHandler = require "kong.plugins.zipkin.opentracing"
 local ZipkinLogHandler = OpenTracingHandler:extend()
 ZipkinLogHandler.VERSION = "scm"
 
+
 function ZipkinLogHandler.new_tracer(conf)
   local tracer = new_tracer(new_zipkin_reporter(conf), new_random_sampler(conf))
   tracer:register_injector("http_headers", zipkin_codec.new_injector())
   tracer:register_extractor("http_headers", zipkin_codec.new_extractor(kong.log.warn))
   return tracer
 end
+
 
 local function log(premature, reporter)
   if premature then
@@ -27,6 +29,7 @@ local function log(premature, reporter)
   end
 end
 
+
 function ZipkinLogHandler:log(conf)
   ZipkinLogHandler.super.log(self, conf)
 
@@ -37,5 +40,6 @@ function ZipkinLogHandler:log(conf)
     kong.log.err("failed to create timer: ", err)
   end
 end
+
 
 return ZipkinLogHandler

--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -30,6 +30,7 @@ function OpenTracingHandler:get_tracer(conf)
   return tracer
 end
 
+
 function OpenTracingHandler:get_context(conf, ctx)
   local opentracing = ctx.opentracing
   if not opentracing then
@@ -38,6 +39,7 @@ function OpenTracingHandler:get_context(conf, ctx)
   end
   return opentracing
 end
+
 
 -- Utility function to set either ipv4 or ipv6 tags
 -- nginx apis don't have a flag to indicate whether an address is v4 or v6
@@ -49,6 +51,7 @@ local function ip_tag(addr)
     return "peer.ipv6"
   end
 end
+
 
 if subsystem == "http" then
   function OpenTracingHandler:initialise_request(conf, ctx)
@@ -64,29 +67,30 @@ if subsystem == "http" then
     end
     local forwarded_ip = kong.client.get_forwarded_ip()
     local request_span = tracer:start_span("kong.request", {
-      child_of = wire_context;
+      child_of = wire_context,
       start_timestamp = ngx.req.start_time(),
       tags = {
-        component = "kong";
-        ["span.kind"] = "server";
-        ["http.method"] = method;
-        ["http.url"] = url;
-        [ip_tag(forwarded_ip)] = forwarded_ip;
-        ["peer.port"] = kong.client.get_forwarded_port();
+        component = "kong",
+        ["span.kind"] = "server",
+        ["http.method"] = method,
+        ["http.url"] = url,
+        [ip_tag(forwarded_ip)] = forwarded_ip,
+        ["peer.port"] = kong.client.get_forwarded_port(),
       }
     })
     ctx.opentracing = {
-      tracer = tracer;
-      wire_context = wire_context;
-      request_span = request_span;
-      rewrite_span = nil;
-      access_span = nil;
-      proxy_span = nil;
-      header_filter_span = nil;
-      header_filter_finished = false;
-      body_filter_span = nil;
+      tracer = tracer,
+      wire_context = wire_context,
+      request_span = request_span,
+      rewrite_span = nil,
+      access_span = nil,
+      proxy_span = nil,
+      header_filter_span = nil,
+      header_filter_finished = false,
+      body_filter_span = nil,
     }
   end
+
 
   function OpenTracingHandler:access(conf)
     local ctx = ngx.ctx
@@ -111,6 +115,7 @@ if subsystem == "http" then
     end
   end
 
+
   function OpenTracingHandler:header_filter(conf)
     local ctx = ngx.ctx
     local opentracing = self:get_context(conf, ctx)
@@ -130,6 +135,7 @@ if subsystem == "http" then
     )
   end
 
+
   function OpenTracingHandler:body_filter(conf)
     local ctx = ngx.ctx
     local opentracing = self:get_context(conf, ctx)
@@ -144,29 +150,32 @@ if subsystem == "http" then
       opentracing.body_filter_span = opentracing.proxy_span:start_child_span("kong.body_filter", now)
     end
   end
+
 elseif subsystem == "stream" then
+
   function OpenTracingHandler:initialise_request(conf, ctx)
     local tracer = self:get_tracer(conf)
     local wire_context = nil
     local forwarded_ip = kong.client.get_forwarded_ip()
     local request_span = tracer:start_span("kong.stream", {
-      child_of = wire_context;
+      child_of = wire_context,
       start_timestamp = ngx.req.start_time(),
       tags = {
-        component = "kong";
-        ["span.kind"] = "server";
-        [ip_tag(forwarded_ip)] = forwarded_ip;
-        ["peer.port"] = kong.client.get_forwarded_port();
+        component = "kong",
+        ["span.kind"] = "server",
+        [ip_tag(forwarded_ip)] = forwarded_ip,
+        ["peer.port"] = kong.client.get_forwarded_port(),
       }
     })
     ctx.opentracing = {
-      tracer = tracer;
-      wire_context = wire_context;
-      request_span = request_span;
-      preread_span = nil;
-      proxy_span = nil;
+      tracer = tracer,
+      wire_context = wire_context,
+      request_span = request_span,
+      preread_span = nil,
+      proxy_span = nil,
     }
   end
+
 
   function OpenTracingHandler:preread(conf)
     local ctx = ngx.ctx
@@ -183,6 +192,7 @@ elseif subsystem == "stream" then
     )
   end
 end
+
 
 function OpenTracingHandler:log(conf)
   local now = ngx.now()

--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -58,15 +58,13 @@ if subsystem == "http" then
     local tracer = self:get_tracer(conf)
     local req = kong.request
     local wire_context = tracer:extract("http_headers", req.get_headers()) -- could be nil
-    local method, url
     local path_with_query = req.get_path_with_query()
-    if path_with_query ~= "" then
-      method = req.get_method()
-      url = req.get_scheme() .. "://" .. req.get_host() .. ":"
-        .. req.get_port() .. path_with_query
-    end
+    local method = req.get_method()
+    local url = req.get_scheme() .. "://" .. req.get_host() .. ":"
+             .. req.get_port() .. path_with_query
     local forwarded_ip = kong.client.get_forwarded_ip()
-    local request_span = tracer:start_span("kong.request", {
+
+    local request_span = tracer:start_span(method .. " " .. url, {
       child_of = wire_context,
       start_timestamp = ngx.req.start_time(),
       tags = {

--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -8,6 +8,7 @@ A plugin that derives this should:
 ]]
 
 local subsystem = ngx.config.subsystem
+local fmt = string.format
 
 local OpenTracingHandler = {
   VERSION = "scm",
@@ -53,6 +54,19 @@ local function ip_tag(addr)
 end
 
 
+-- adds the proxy span to the opentracing context, unless it already exists
+local function get_or_add_proxy_span(opentracing, timestamp)
+  if not opentracing.proxy_span then
+    local request_span = opentracing.request_span
+    opentracing.proxy_span = request_span:start_child_span(
+      request_span.name .. " (proxy)",
+      timestamp)
+    opentracing.proxy_span:set_tag("span.kind", "client")
+  end
+  return opentracing.proxy_span
+end
+
+
 if subsystem == "http" then
   function OpenTracingHandler:initialise_request(conf, ctx)
     local tracer = self:get_tracer(conf)
@@ -80,13 +94,18 @@ if subsystem == "http" then
       tracer = tracer,
       wire_context = wire_context,
       request_span = request_span,
-      rewrite_span = nil,
-      access_span = nil,
       proxy_span = nil,
-      header_filter_span = nil,
       header_filter_finished = false,
-      body_filter_span = nil,
     }
+  end
+
+
+  function OpenTracingHandler:rewrite(conf)
+    local ctx = ngx.ctx
+    local opentracing = self:get_context(conf, ctx)
+    -- note: rewrite is logged on the request_span, not on the proxy span
+    local rewrite_start = ctx.KONG_REWRITE_START / 1000
+    opentracing.request_span:log("kong.rewrite", "start", rewrite_start)
   end
 
 
@@ -94,15 +113,7 @@ if subsystem == "http" then
     local ctx = ngx.ctx
     local opentracing = self:get_context(conf, ctx)
 
-    opentracing.proxy_span = opentracing.request_span:start_child_span(
-      "kong.proxy",
-      ctx.KONG_ACCESS_START / 1000
-    )
-
-    opentracing.access_span = opentracing.proxy_span:start_child_span(
-      "kong.access",
-      ctx.KONG_ACCESS_START / 1000
-    )
+    get_or_add_proxy_span(opentracing, ctx.KONG_ACCESS_START / 1000)
 
     -- Want to send headers to upstream
     local outgoing_headers = {}
@@ -117,20 +128,12 @@ if subsystem == "http" then
   function OpenTracingHandler:header_filter(conf)
     local ctx = ngx.ctx
     local opentracing = self:get_context(conf, ctx)
+    local header_filter_start =
+      ctx.KONG_HEADER_FILTER_STARTED_AT and ctx.KONG_HEADER_FILTER_STARTED_AT / 1000
+      or ngx.now()
 
-    local header_started = ctx.KONG_HEADER_FILTER_STARTED_AT and ctx.KONG_HEADER_FILTER_STARTED_AT / 1000 or ngx.now()
-
-    if not opentracing.proxy_span then
-      opentracing.proxy_span = opentracing.request_span:start_child_span(
-        "kong.proxy",
-        header_started
-      )
-    end
-
-    opentracing.header_filter_span = opentracing.proxy_span:start_child_span(
-      "kong.header_filter",
-      header_started
-    )
+    local proxy_span = get_or_add_proxy_span(opentracing, header_filter_start)
+    proxy_span:log("kong.header_filter", "start", header_filter_start)
   end
 
 
@@ -142,10 +145,9 @@ if subsystem == "http" then
     if not opentracing.header_filter_finished then
       local now = ngx.now()
 
-      opentracing.header_filter_span:finish(now)
+      opentracing.proxy_span:log("kong.header_filter", "finish", now)
       opentracing.header_filter_finished = true
-
-      opentracing.body_filter_span = opentracing.proxy_span:start_child_span("kong.body_filter", now)
+      opentracing.proxy_span:log("kong.body_filter", "start", now)
     end
   end
 
@@ -169,7 +171,6 @@ elseif subsystem == "stream" then
       tracer = tracer,
       wire_context = wire_context,
       request_span = request_span,
-      preread_span = nil,
       proxy_span = nil,
     }
   end
@@ -178,16 +179,10 @@ elseif subsystem == "stream" then
   function OpenTracingHandler:preread(conf)
     local ctx = ngx.ctx
     local opentracing = self:get_context(conf, ctx)
+    local preread_start = ctx.KONG_PREREAD_START / 1000
 
-    opentracing.proxy_span = opentracing.request_span:start_child_span(
-      "kong.proxy",
-      ctx.KONG_PREREAD_START / 1000
-    )
-
-    opentracing.preread_span = opentracing.proxy_span:start_child_span(
-      "kong.preread",
-      ctx.KONG_PREREAD_START / 1000
-    )
+    local proxy_span = get_or_add_proxy_span(opentracing, preread_start)
+    proxy_span:log("kong.preread", "start", preread_start)
   end
 end
 
@@ -197,42 +192,58 @@ function OpenTracingHandler:log(conf)
   local ctx = ngx.ctx
   local opentracing = self:get_context(conf, ctx)
   local request_span = opentracing.request_span
+  local proxy_span = get_or_add_proxy_span(opentracing, now)
 
-  local proxy_span = opentracing.proxy_span
-  if not proxy_span then
-    proxy_span = request_span:start_child_span("kong.proxy", now)
-    opentracing.proxy_span = proxy_span
-  end
-  proxy_span:set_tag("span.kind", "client")
-  local proxy_end = ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT/1000 or now
+  local proxy_finish =
+    ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT / 1000 or now
 
-  -- We'd run this in rewrite phase, but then we wouldn't have per-service configuration of this plugin
   if ctx.KONG_REWRITE_TIME then
-    opentracing.rewrite_span = opentracing.request_span:start_child_span(
-      "kong.rewrite",
-      ctx.KONG_REWRITE_START / 1000
-    ):finish((ctx.KONG_REWRITE_START + ctx.KONG_REWRITE_TIME) / 1000)
+    -- note: rewrite is logged on the request span, not on the proxy span
+    local rewrite_finish = (ctx.KONG_REWRITE_START + ctx.KONG_REWRITE_TIME) / 1000
+    opentracing.request_span:log("kong.rewrite", "finish", rewrite_finish)
   end
 
-  if opentracing.access_span then
-    opentracing.access_span:finish(ctx.KONG_ACCESS_ENDED_AT and ctx.KONG_ACCESS_ENDED_AT/1000 or proxy_end)
-  elseif opentracing.preread_span then
-    opentracing.preread_span:finish(ctx.KONG_PREREAD_ENDED_AT and ctx.KONG_PREREAD_ENDED_AT/1000 or proxy_end)
+  if subsystem == "http" then
+    -- add access_start here instead of in the access phase
+    -- because the plugin access phase is skipped when dealing with
+    -- requests which are not matched by any route
+    -- but we still want to know when the access phase "started"
+    local access_start = ctx.KONG_ACCESS_START / 1000
+    proxy_span:log("kong.access", "start", access_start)
+
+    local access_finish =
+      ctx.KONG_ACCESS_ENDED_AT and ctx.KONG_ACCESS_ENDED_AT / 1000 or proxy_finish
+    proxy_span:log("kong.access", "finish", access_finish)
+
+    if not opentracing.header_filter_finished then
+      proxy_span:log("kong.header_filter", "finish", now)
+      opentracing.header_filter_finished = true
+    end
+
+    proxy_span:log("kong.body_filter", "finish", now)
+
+  else
+    local preread_finish =
+      ctx.KONG_PREREAD_ENDED_AT and ctx.KONG_PREREAD_ENDED_AT / 1000 or proxy_finish
+    proxy_span:log("kong.preread", "finish", preread_finish)
   end
 
   local balancer_data = ctx.balancer_data
   if balancer_data then
     local balancer_tries = balancer_data.tries
-    for i=1, balancer_data.try_count do
+    for i = 1, balancer_data.try_count do
       local try = balancer_tries[i]
-      local span = proxy_span:start_child_span("kong.balancer", try.balancer_start / 1000)
+      local name = fmt("%s (balancer try %d)", request_span.name, i)
+      local span = request_span:start_child_span(name, try.balancer_start / 1000)
       span:set_tag(ip_tag(try.ip), try.ip)
       span:set_tag("peer.port", try.port)
       span:set_tag("kong.balancer.try", i)
       if i < balancer_data.try_count then
         span:set_tag("error", true)
         span:set_tag("kong.balancer.state", try.state)
-        span:set_tag("kong.balancer.code", try.code)
+        span:set_tag("http.status_code", try.code)
+      else
+        span:set_tag("error", false)
       end
       span:finish((try.balancer_start + try.balancer_latency) / 1000)
     end
@@ -241,15 +252,6 @@ function OpenTracingHandler:log(conf)
        proxy_span:set_tag(ip_tag(balancer_data.ip), balancer_data.ip)
     end
     proxy_span:set_tag("peer.port", balancer_data.port)
-  end
-
-  if not opentracing.header_filter_finished and opentracing.header_filter_span then
-    opentracing.header_filter_span:finish(now)
-    opentracing.header_filter_finished = true
-  end
-
-  if opentracing.body_filter_span then
-    opentracing.body_filter_span:finish(proxy_end)
   end
 
   if subsystem == "http" then
@@ -262,18 +264,20 @@ function OpenTracingHandler:log(conf)
     request_span:set_tag("kong.credential", ctx.authenticated_credential.id)
   end
   request_span:set_tag("kong.node.id", kong.node.get_id())
+  -- TODO: should we add these tags to the request span and/or the balancer spans?
   if ctx.service and ctx.service.id then
     proxy_span:set_tag("kong.service", ctx.service.id)
     if ctx.route and ctx.route.id then
       proxy_span:set_tag("kong.route", ctx.route.id)
     end
-    if ctx.service.name ~= ngx.null then
+    if type(ctx.service.name) == "string" then
       proxy_span:set_tag("peer.service", ctx.service.name)
     end
   elseif ctx.api and ctx.api.id then
     proxy_span:set_tag("kong.api", ctx.api.id)
   end
-  proxy_span:finish(proxy_end)
+
+  proxy_span:finish(proxy_finish)
   request_span:finish(now)
 end
 

--- a/kong/plugins/zipkin/random_sampler.lua
+++ b/kong/plugins/zipkin/random_sampler.lua
@@ -1,21 +1,24 @@
 local random_sampler_methods = {}
 local random_sampler_mt = {
-  __name = "kong.plugins.zipkin.random_sampler";
-  __index = random_sampler_methods;
+  __name = "kong.plugins.zipkin.random_sampler",
+  __index = random_sampler_methods,
 }
+
 
 local function new_random_sampler(conf)
   local sample_ratio = conf.sample_ratio
   assert(type(sample_ratio) == "number" and sample_ratio >= 0 and sample_ratio <= 1, "invalid sample_ratio")
   return setmetatable({
-    sample_ratio = sample_ratio;
+    sample_ratio = sample_ratio,
   }, random_sampler_mt)
 end
+
 
 function random_sampler_methods:sample(name) -- luacheck: ignore 212
   return math.random() < self.sample_ratio
 end
 
+
 return {
-  new = new_random_sampler;
+  new = new_random_sampler,
 }

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -46,6 +46,11 @@ function zipkin_reporter_methods:report(span)
   local span_kind = zipkin_tags["span.kind"]
   zipkin_tags["span.kind"] = nil
 
+  -- rename component tag to lc ("local component")
+  local component = zipkin_tags["component"]
+  zipkin_tags["component"] = nil
+  zipkin_tags["lc"] = component
+
   local localEndpoint do
     local serviceName = zipkin_tags["peer.service"]
     if serviceName then

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -40,7 +40,11 @@ function zipkin_reporter_methods:report(span)
     -- Zipkin tag values should be strings
     -- see https://zipkin.io/zipkin-api/#/default/post_spans
     -- and https://github.com/Kong/kong-plugin-zipkin/pull/13#issuecomment-402389342
-    zipkin_tags[k] = tostring(v)
+    -- Zipkin tags should be non-empty
+    -- see https://github.com/openzipkin/zipkin/pull/2834#discussion_r332125458
+    if v ~= "" then
+      zipkin_tags[k] = tostring(v)
+    end
   end
 
   local span_kind = zipkin_tags["span.kind"]

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -7,6 +7,18 @@ local http_server = require "http.server"
 local new_headers = require "http.headers".new
 local cjson = require "cjson"
 
+-- Transform zipkin annotations into a hash of timestamps. It assumes no repeated events
+-- input: { { event = x, timestamp = y }, { event = x2, timestamp = y2 } }
+-- output: { x = y, x2 = y2 }
+local function annotations_to_hash(annotations)
+  local hash = {}
+  for _, a in ipairs(annotations) do
+    assert(not hash[a.event], "duplicated annotation: " .. a.event)
+    hash[a.event] = a.timestamp
+  end
+  return hash
+end
+
 
 for _, strategy in helpers.each_strategy() do
 describe("integration tests with mock zipkin server [#" .. strategy .. "]", function()
@@ -14,6 +26,8 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
 
   local cb
   local proxy_port, proxy_host
+  local zipkin_port, zipkin_host
+  local service, route
   after_each(function()
     cb = nil
   end)
@@ -39,11 +53,66 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
     end
   end
 
+
+  -- the following assertions should be true on any span list, even in error mode
+  local function assert_span_invariants(request_span, proxy_span, expected_name)
+    -- request_span
+    assert.same("table", type(request_span))
+    assert.same("string", type(request_span.id))
+    assert.same(expected_name, request_span.name)
+    assert.same(request_span.id, proxy_span.parentId)
+
+    assert.same("SERVER", request_span.kind)
+
+    assert.same("string", type(request_span.traceId))
+    assert.truthy(request_span.traceId:match("^%x+$"))
+    assert.same("number", type(request_span.timestamp))
+    assert.truthy(request_span.duration >= proxy_span.duration)
+
+    assert.equals(2, #request_span.annotations)
+    local rann = annotations_to_hash(request_span.annotations)
+    assert.equals("number", type(rann["kong.rewrite.start"]))
+    assert.equals("number", type(rann["kong.rewrite.finish"]))
+    assert.truthy(rann["kong.rewrite.start"] <= rann["kong.rewrite.finish"])
+
+    assert.same(ngx.null, request_span.localEndpoint)
+
+    -- proxy_span
+    assert.same("table", type(proxy_span))
+    assert.same("string", type(proxy_span.id))
+    assert.same(request_span.name .. " (proxy)", proxy_span.name)
+    assert.same(request_span.id, proxy_span.parentId)
+
+    assert.same("CLIENT", proxy_span.kind)
+
+    assert.same("string", type(proxy_span.traceId))
+    assert.truthy(proxy_span.traceId:match("^%x+$"))
+    assert.same("number", type(proxy_span.timestamp))
+    assert.truthy(proxy_span.duration >= 0)
+
+    assert.equals(6, #proxy_span.annotations)
+    local pann = annotations_to_hash(proxy_span.annotations)
+
+    assert.equals("number", type(pann["kong.access.start"]))
+    assert.equals("number", type(pann["kong.access.finish"]))
+    assert.equals("number", type(pann["kong.header_filter.start"]))
+    assert.equals("number", type(pann["kong.header_filter.finish"]))
+    assert.equals("number", type(pann["kong.body_filter.start"]))
+    assert.equals("number", type(pann["kong.body_filter.finish"]))
+
+    assert.truthy(pann["kong.access.start"]        <= pann["kong.access.finish"])
+    assert.truthy(pann["kong.header_filter.start"] <= pann["kong.header_filter.finish"])
+    assert.truthy(pann["kong.body_filter.start"]   <= pann["kong.body_filter.finish"])
+
+    assert.truthy(pann["kong.header_filter.start"] <= pann["kong.body_filter.start"])
+  end
+
+
   setup(function()
     -- create a mock zipkin server
     server = assert(http_server.listen {
-      host = "127.0.0.1";
-      port = 0;
+      host = "127.0.0.1",
+      port = 0,
       onstream = function(_, stream)
         local req_headers = assert(stream:get_headers())
         local res_headers = new_headers()
@@ -53,10 +122,11 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
         local body = cb(req_headers, res_headers, stream)
         assert(stream:write_headers(res_headers, false))
         assert(stream:write_chunk(body or "", true))
-      end;
+      end,
     })
     assert(server:listen())
-    local _, ip, port = server:localname()
+    local _
+    _, zipkin_host, zipkin_port = server:localname()
 
     local bp = helpers.get_db_utils(strategy, { "services", "routes", "plugins" })
 
@@ -65,17 +135,17 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       name = "zipkin",
       config = {
         sample_ratio = 1,
-        http_endpoint = string.format("http://%s:%d/api/v2/spans", ip, port),
+        http_endpoint = string.format("http://%s:%d/api/v2/spans", zipkin_host, zipkin_port),
       }
     })
 
     -- create service+route pointing at the zipkin server
-    local service = bp.services:insert({
+    service = bp.services:insert({
       name = "mock-zipkin",
-      url = string.format("http://%s:%d", ip, port),
+      url = string.format("http://%s:%d", zipkin_host, zipkin_port),
     })
 
-    bp.routes:insert({
+    route = bp.routes:insert({
       service = { id = service.id },
       hosts = { "mock-zipkin-route" },
       preserve_host = true,
@@ -89,72 +159,146 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
     proxy_port = helpers.get_proxy_port(false)
   end)
 
-
   teardown(function()
     server:close()
     helpers.stop_kong()
   end)
 
-  it("vaguely works", function()
+  it("generates spans, tags and annotations for regular requests", function()
     assert.truthy(with_server(function(req_headers, res_headers, stream)
       if req_headers:get(":authority") == "mock-zipkin-route" then
         -- is the request itself
         res_headers:upsert(":status", "204")
       else
-        local body = cjson.decode((assert(stream:get_body_as_string())))
-        assert.same("table", type(body))
-        assert.same("table", type(body[1]))
-        for _, v in ipairs(body) do
-          assert.same("string", type(v.traceId))
-          assert.truthy(v.traceId:match("^%x+$"))
-          assert.same("number", type(v.timestamp))
-          assert.same("table", type(v.tags))
-          assert.truthy(v.duration >= 0)
-        end
+        local spans = cjson.decode((assert(stream:get_body_as_string())))
+        assert.equals(3, #spans)
+        local balancer_span, proxy_span, request_span = spans[1], spans[2], spans[3]
+        local url = string.format("http://mock-zipkin-route:%d/", proxy_port)
+        -- common assertions for request_span and proxy_span
+        assert_span_invariants(request_span, proxy_span, "GET " .. url)
+
+        -- specific assertions for request_span
+        local request_tags = request_span.tags
+        assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
+        request_tags["kong.node.id"] = nil
+        assert.same({
+          ["http.method"] = "GET",
+          ["http.url"] = url,
+          ["http.status_code"] = "204", -- found (matches server status)
+          lc = "kong"
+        }, request_tags)
+        local peer_port = request_span.remoteEndpoint.port
+        assert.equals("number", type(peer_port))
+        assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
+
+        -- specific assertions for proxy_span
+        assert.same({
+          ["kong.route"] = route.id,
+          ["kong.service"] = service.id,
+          ["peer.hostname"] = "127.0.0.1",
+        }, proxy_span.tags)
+
+        assert.same({ ipv4 = zipkin_host, port = zipkin_port }, proxy_span.remoteEndpoint)
+        assert.same({ serviceName = "mock-zipkin" }, proxy_span.localEndpoint)
+
+        -- specific assertions for balancer_span
+        assert.equals(balancer_span.parentId, request_span.id)
+        assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
+        assert.equals("number", type(balancer_span.timestamp))
+        assert.equals("number", type(balancer_span.duration))
+        assert.same({ ipv4 = zipkin_host, port = zipkin_port }, balancer_span.remoteEndpoint)
+        assert.equals(ngx.null, balancer_span.localEndpoint)
+        assert.same({
+          error = "false",
+          ["kong.balancer.try"] = "1",
+        }, balancer_span.tags)
+
         res_headers:upsert(":status", "204")
       end
     end, function()
+      -- regular request which matches the existing route
       local req = http_request.new_from_uri("http://mock-zipkin-route/")
       req.host = proxy_host
       req.port = proxy_port
       assert(req:go())
     end))
   end)
-  it("uses trace id from request", function()
-    local trace_id = "1234567890abcdef"
+
+  it("generates spans, tags and annotations for non-matched requests", function()
     assert.truthy(with_server(function(_, res_headers, stream)
-      local body = cjson.decode((assert(stream:get_body_as_string())))
-      for _, v in ipairs(body) do
-        assert.same(trace_id, v.traceId)
-      end
-      res_headers:upsert(":status", "204")
+      local spans = cjson.decode((assert(stream:get_body_as_string())))
+      assert.equals(2, #spans)
+      local proxy_span, request_span = spans[1], spans[2]
+      local url = string.format("http://0.0.0.0:%d/", proxy_port)
+      -- common assertions for request_span and proxy_span
+      assert_span_invariants(request_span, proxy_span, "GET " .. url)
+
+      -- specific assertions for request_span
+      local request_tags = request_span.tags
+      assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
+      request_tags["kong.node.id"] = nil
+      assert.same({
+        ["http.method"] = "GET",
+        ["http.url"] = url,
+        ["http.status_code"] = "404", -- note that this was "not found"
+        lc = "kong"
+      }, request_tags)
+      local peer_port = request_span.remoteEndpoint.port
+      assert.equals("number", type(peer_port))
+      assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
+
+      -- specific assertions for proxy_span
+      assert.is_nil(proxy_span.tags)
+
+      assert.equals(ngx.null, proxy_span.remoteEndpoint)
+      assert.equals(ngx.null, proxy_span.localEndpoint)
+
+      res_headers:upsert(":status", "204") -- note the returned status by the server is 204
     end, function()
+      -- This request reaches the proxy, but doesn't match any route.
+      -- The plugin runs in "error mode": access phase doesn't run, but others, like header_filter, do run
       local uri = string.format("http://%s:%d/", proxy_host, proxy_port)
       local req = http_request.new_from_uri(uri)
-      req.headers:upsert("x-b3-traceid", trace_id)
-      req.headers:upsert("x-b3-sampled", "1")
       assert(req:go())
     end))
   end)
-  it("propagates b3 headers", function()
+
+  it("propagates b3 headers on routed request", function()
     local trace_id = "1234567890abcdef"
     assert.truthy(with_server(function(req_headers, res_headers, stream)
-      if req_headers:get(":authority") == "mock-zipkin" then
-        -- this is our proxied request
-        assert.same(trace_id, req_headers:get("x-b3-traceid"))
-        assert.same("1", req_headers:get("x-b3-sampled"))
+      if req_headers:get(":authority") == "mock-zipkin-route" then
+        -- is the request itself
+        res_headers:upsert(":status", "204")
       else
-        -- we are playing role of zipkin server
-        local body = cjson.decode((assert(stream:get_body_as_string())))
-        for _, v in ipairs(body) do
+        local spans = cjson.decode((assert(stream:get_body_as_string())))
+        for _, v in ipairs(spans) do
           assert.same(trace_id, v.traceId)
         end
         res_headers:upsert(":status", "204")
       end
     end, function()
-      local req = http_request.new_from_uri("http://mock-zipkin/")
+      -- regular request, with extra headers
+      local req = http_request.new_from_uri("http://mock-zipkin-route/")
       req.host = proxy_host
       req.port = proxy_port
+      req.headers:upsert("x-b3-traceid", trace_id)
+      req.headers:upsert("x-b3-sampled", "1")
+      assert(req:go())
+    end))
+  end)
+
+  it("propagates b3 headers on routed request", function()
+    local trace_id = "1234567890abcdef"
+    assert.truthy(with_server(function(_, res_headers, stream)
+      local spans = cjson.decode((assert(stream:get_body_as_string())))
+      for _, v in ipairs(spans) do
+        assert.same(trace_id, v.traceId)
+      end
+      res_headers:upsert(":status", "204")
+    end, function()
+      -- This request reaches the proxy, but doesn't match any route. The trace_id should be respected here too
+      local uri = string.format("http://%s:%d/", proxy_host, proxy_port)
+      local req = http_request.new_from_uri(uri)
       req.headers:upsert("x-b3-traceid", trace_id)
       req.headers:upsert("x-b3-sampled", "1")
       assert(req:go())


### PR DESCRIPTION
Fixes #49 

It is *highly recommended* to review this PR commit-by-commit, but notice that github's UI does not list them in the appropriate order.

The initial commits (on `git log`, not on github's UI) deal with the fact that the current specs were not included on the CI environment (only the linter was called) and they were run in a non-standard way (i.e. Kong was run in production mode, not in test mode).

The `feat` commits detail the new changes:
* The Opentracing `component` tag is renamed to `lc` for zipkin
* Empty tags are not sent to zipkin
* The spans have also been restructured:
  * Request span is the parent, proxy span is for kong internal processing, balancer span(s) for balancer tries.
  * The balancer spans are now children of the request span instead of the proxy span, and they always contain the `error` tag, set to `true` or `false`.
  * The Kong phases were previously encoded as individual spans. Now they have been converted into Opentracing logs / Zipkin annotations inside the request span and proxy span.
* The spans for http traffic have been renamed:
  * `GET http://host:port` for the request span
  * `GET http://host:port (proxy)` for the proxy span
  * `GET http://host:port (balancer try n)` for each balancer try

All these changes are tested on the last commit.