### PR TITLE
fixes: http.path and span name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
     - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_LATEST TEST_SUITE=plugins
 
 install:
-  - git clone --single-branch https://$GITHUB_TOKEN:@github.com/Kong/kong-ci ../kong-ci
+  - git clone --single-branch https://$GITHUB_TOKEN:@github.com/Kong/kong-ci.git ../kong-ci
   - source ../kong-ci/setup_plugin_env.sh
 
 script:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Of those, this plugin currently uses:
   - `span.kind` (sent to Zipkin as "kind")
   - `http.method`
   - `http.status_code`
-  - `http.url`
+  - `http.path`
   - `error`
   - `peer.ipv4`
   - `peer.ipv6`

--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -72,20 +72,17 @@ if subsystem == "http" then
     local tracer = self:get_tracer(conf)
     local req = kong.request
     local wire_context = tracer:extract("http_headers", req.get_headers()) -- could be nil
-    local path_with_query = req.get_path_with_query()
     local method = req.get_method()
-    local url = req.get_scheme() .. "://" .. req.get_host() .. ":"
-             .. req.get_port() .. path_with_query
     local forwarded_ip = kong.client.get_forwarded_ip()
 
-    local request_span = tracer:start_span(method .. " " .. url, {
+    local request_span = tracer:start_span(method .. " " .. path, {
       child_of = wire_context,
       start_timestamp = ngx.req.start_time(),
       tags = {
         component = "kong",
         ["span.kind"] = "server",
         ["http.method"] = method,
-        ["http.url"] = url,
+        ["http.path"] = req.get_path(),
         [ip_tag(forwarded_ip)] = forwarded_ip,
         ["peer.port"] = kong.client.get_forwarded_port(),
       }

--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -75,7 +75,7 @@ if subsystem == "http" then
     local method = req.get_method()
     local forwarded_ip = kong.client.get_forwarded_ip()
 
-    local request_span = tracer:start_span(method .. " " .. path, {
+    local request_span = tracer:start_span(method, {
       child_of = wire_context,
       start_timestamp = ngx.req.start_time(),
       tags = {

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -173,9 +173,8 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
         local spans = cjson.decode((assert(stream:get_body_as_string())))
         assert.equals(3, #spans)
         local balancer_span, proxy_span, request_span = spans[1], spans[2], spans[3]
-        local url = string.format("http://mock-zipkin-route:%d/", proxy_port)
         -- common assertions for request_span and proxy_span
-        assert_span_invariants(request_span, proxy_span, "GET " .. url)
+        assert_span_invariants(request_span, proxy_span, "GET")
 
         -- specific assertions for request_span
         local request_tags = request_span.tags
@@ -229,9 +228,8 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       local spans = cjson.decode((assert(stream:get_body_as_string())))
       assert.equals(2, #spans)
       local proxy_span, request_span = spans[1], spans[2]
-      local url = string.format("http://0.0.0.0:%d/", proxy_port)
       -- common assertions for request_span and proxy_span
-      assert_span_invariants(request_span, proxy_span, "GET " .. url)
+      assert_span_invariants(request_span, proxy_span, "GET")
 
       -- specific assertions for request_span
       local request_tags = request_span.tags

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -183,7 +183,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
         request_tags["kong.node.id"] = nil
         assert.same({
           ["http.method"] = "GET",
-          ["http.url"] = url,
+          ["http.path"] = "/",
           ["http.status_code"] = "204", -- found (matches server status)
           lc = "kong"
         }, request_tags)
@@ -239,7 +239,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       request_tags["kong.node.id"] = nil
       assert.same({
         ["http.method"] = "GET",
-        ["http.url"] = url,
+        ["http.path"] = "/",
         ["http.status_code"] = "404", -- note that this was "not found"
         lc = "kong"
       }, request_tags)


### PR DESCRIPTION
This PR includes 3 fixes:

* A fix on `travis.yml` which (possibly) made CI fail on certain setups
* Use of `http.path` instead of `http.url` (#56)
* Change the name of http spans to use `GET` instead of `GET http://foo.bar/baz`

The last two changes are discussed in #52. 