### PR TITLE
fix(*) timestamps and annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ env:
 install:
   - git clone --single-branch https://$GITHUB_TOKEN:@github.com/Kong/kong-ci.git ../kong-ci
   - source ../kong-ci/setup_plugin_env.sh
+  - docker run -d --name zipkin -p 9411:9411 openzipkin/zipkin && while ! curl localhost:9411/health; do sleep 1; done
 
 script:
   - eval $LUACHECK_CMD

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -100,7 +100,7 @@ function zipkin_reporter_methods:report(span)
       for i = 1, n_logs do
         local log = span.logs[i]
         annotations[i] = {
-          event = log.key .. "." .. log.value,
+          value = log.key .. "." .. log.value,
           timestamp = floor(log.timestamp),
         }
       end

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -101,7 +101,7 @@ function zipkin_reporter_methods:report(span)
         local log = span.logs[i]
         annotations[i] = {
           event = log.key .. "." .. log.value,
-          timestamp = log.timestamp,
+          timestamp = floor(log.timestamp),
         }
       end
     end
@@ -117,7 +117,7 @@ function zipkin_reporter_methods:report(span)
     parentId = span_context.parent_id and to_hex(span_context.parent_id) or nil,
     id = to_hex(span_context.span_id),
     kind = span_kind_map[span_kind],
-    timestamp = span.timestamp * 1000000,
+    timestamp = floor(span.timestamp * 1000000),
     duration = floor(span.duration * 1000000), -- zipkin wants integer
     -- shared = nil, -- We don't use shared spans (server reuses client generated spanId)
     -- TODO: debug?

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -4,6 +4,7 @@ local cjson = require "cjson".new()
 cjson.encode_number_precision(16)
 
 local floor = math.floor
+local gsub = string.gsub
 
 local zipkin_reporter_methods = {}
 local zipkin_reporter_mt = {
@@ -99,8 +100,14 @@ function zipkin_reporter_methods:report(span)
       annotations = kong.table.new(n_logs, 0)
       for i = 1, n_logs do
         local log = span.logs[i]
+
+        -- Shortens the log strings into annotation values
+        -- for Zipkin. "kong.access.start" becomes "kas"
+        local value = gsub(log.key .. "." .. log.value,
+                           "%.?(%w)[^%.]*",
+                           "%1")
         annotations[i] = {
-          value = log.key .. "." .. log.value,
+          value     = value,
           timestamp = floor(log.timestamp),
         }
       end

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -19,6 +19,12 @@ local function annotations_to_hash(annotations)
   return hash
 end
 
+local function assert_is_integer(number)
+  assert.equals("number", type(number))
+  assert.equals(number, math.floor(number))
+end
+
+
 
 for _, strategy in helpers.each_strategy() do
 describe("integration tests with mock zipkin server [#" .. strategy .. "]", function()
@@ -68,13 +74,13 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
 
     assert.same("string", type(request_span.traceId))
     assert.truthy(request_span.traceId:match("^%x+$"))
-    assert.same("number", type(request_span.timestamp))
+    assert_is_integer(request_span.timestamp)
     assert.truthy(request_span.duration >= proxy_span.duration)
 
     assert.equals(2, #request_span.annotations)
     local rann = annotations_to_hash(request_span.annotations)
-    assert.equals("number", type(rann["kong.rewrite.start"]))
-    assert.equals("number", type(rann["kong.rewrite.finish"]))
+    assert_is_integer(rann["kong.rewrite.start"])
+    assert_is_integer(rann["kong.rewrite.finish"])
     assert.truthy(rann["kong.rewrite.start"] <= rann["kong.rewrite.finish"])
 
     assert.same(ngx.null, request_span.localEndpoint)
@@ -89,18 +95,18 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
 
     assert.same("string", type(proxy_span.traceId))
     assert.truthy(proxy_span.traceId:match("^%x+$"))
-    assert.same("number", type(proxy_span.timestamp))
+    assert_is_integer(proxy_span.timestamp)
     assert.truthy(proxy_span.duration >= 0)
 
     assert.equals(6, #proxy_span.annotations)
     local pann = annotations_to_hash(proxy_span.annotations)
 
-    assert.equals("number", type(pann["kong.access.start"]))
-    assert.equals("number", type(pann["kong.access.finish"]))
-    assert.equals("number", type(pann["kong.header_filter.start"]))
-    assert.equals("number", type(pann["kong.header_filter.finish"]))
-    assert.equals("number", type(pann["kong.body_filter.start"]))
-    assert.equals("number", type(pann["kong.body_filter.finish"]))
+    assert_is_integer(pann["kong.access.start"])
+    assert_is_integer(pann["kong.access.finish"])
+    assert_is_integer(pann["kong.header_filter.start"])
+    assert_is_integer(pann["kong.header_filter.finish"])
+    assert_is_integer(pann["kong.body_filter.start"])
+    assert_is_integer(pann["kong.body_filter.finish"])
 
     assert.truthy(pann["kong.access.start"]        <= pann["kong.access.finish"])
     assert.truthy(pann["kong.header_filter.start"] <= pann["kong.header_filter.finish"])
@@ -194,7 +200,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
         lc = "kong"
       }, request_tags)
       local peer_port = request_span.remoteEndpoint.port
-      assert.equals("number", type(peer_port))
+      assert_is_integer(peer_port)
       assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
 
       -- specific assertions for proxy_span
@@ -207,8 +213,8 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       -- specific assertions for balancer_span
       assert.equals(balancer_span.parentId, request_span.id)
       assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
-      assert.equals("number", type(balancer_span.timestamp))
-      assert.equals("number", type(balancer_span.duration))
+      assert_is_integer(balancer_span.timestamp)
+      assert_is_integer(balancer_span.duration)
 
       assert.same({ ipv4 = helpers.mock_upstream_host, port = helpers.mock_upstream_port },
         balancer_span.remoteEndpoint)
@@ -246,7 +252,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
         lc = "kong"
       }, request_tags)
       local peer_port = request_span.remoteEndpoint.port
-      assert.equals("number", type(peer_port))
+      assert_is_integer(peer_port)
       assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
 
       -- specific assertions for proxy_span
@@ -259,8 +265,8 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       -- specific assertions for balancer_span
       assert.equals(balancer_span.parentId, request_span.id)
       assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
-      assert.equals("number", type(balancer_span.timestamp))
-      assert.equals("number", type(balancer_span.duration))
+      assert_is_integer(balancer_span.timestamp)
+      assert_is_integer(balancer_span.duration)
 
       assert.same({ ipv4 = "127.0.0.1", port = 15002 },
         balancer_span.remoteEndpoint)
@@ -304,7 +310,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
         lc = "kong"
       }, request_tags)
       local peer_port = request_span.remoteEndpoint.port
-      assert.equals("number", type(peer_port))
+      assert_is_integer(peer_port)
       assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
 
       -- specific assertions for proxy_span

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -7,14 +7,14 @@ local http_server = require "http.server"
 local new_headers = require "http.headers".new
 local cjson = require "cjson"
 
--- Transform zipkin annotations into a hash of timestamps. It assumes no repeated events
--- input: { { event = x, timestamp = y }, { event = x2, timestamp = y2 } }
+-- Transform zipkin annotations into a hash of timestamps. It assumes no repeated values
+-- input: { { value = x, timestamp = y }, { value = x2, timestamp = y2 } }
 -- output: { x = y, x2 = y2 }
 local function annotations_to_hash(annotations)
   local hash = {}
   for _, a in ipairs(annotations) do
-    assert(not hash[a.event], "duplicated annotation: " .. a.event)
-    hash[a.event] = a.timestamp
+    assert(not hash[a.value], "duplicated annotation: " .. a.value)
+    hash[a.value] = a.timestamp
   end
   return hash
 end

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -1,11 +1,8 @@
-local TEST_TIMEOUT = 2
-
-local cqueues = require "cqueues"
 local helpers = require "spec.helpers"
-local http_request = require "http.request"
-local http_server = require "http.server"
-local new_headers = require "http.headers".new
 local cjson = require "cjson"
+local utils = require "kong.tools.utils"
+local to_hex = require "resty.string".to_hex
+
 
 -- Transform zipkin annotations into a hash of timestamps. It assumes no repeated values
 -- input: { { value = x, timestamp = y }, { value = x2, timestamp = y2 } }
@@ -19,48 +16,24 @@ local function annotations_to_hash(annotations)
   return hash
 end
 
+
 local function assert_is_integer(number)
   assert.equals("number", type(number))
   assert.equals(number, math.floor(number))
 end
 
 
+local function gen_trace_id()
+  return to_hex(utils.get_rand_bytes(8, true))
+end
+
 
 for _, strategy in helpers.each_strategy() do
-describe("integration tests with mock zipkin server [#" .. strategy .. "]", function()
-  local server
-
-  local cb
-  local proxy_port, proxy_host
-  local zipkin_port, zipkin_host
+describe("integration tests with zipkin server [#" .. strategy .. "]", function()
   local proxy_client_grpc
   local route, grpc_route
-
-  after_each(function()
-    cb = nil
-  end)
-
-  local with_server do
-    local function assert_loop(cq, timeout)
-      local ok, err, _, thd = cq:loop(timeout)
-      if not ok then
-        if thd then
-          err = debug.traceback(thd, err)
-        end
-        error(err, 2)
-      end
-    end
-
-    with_server = function(server_cb, client_cb)
-      cb = spy.new(server_cb)
-      local cq = cqueues.new()
-      cq:wrap(assert_loop, server)
-      cq:wrap(client_cb)
-      assert_loop(cq, TEST_TIMEOUT)
-      return (cb:called())
-    end
-  end
-
+  local zipkin_client
+  local proxy_client
 
   -- the following assertions should be true on any span list, even in error mode
   local function assert_span_invariants(request_span, proxy_span, expected_name)
@@ -75,7 +48,10 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
     assert.same("string", type(request_span.traceId))
     assert.truthy(request_span.traceId:match("^%x+$"))
     assert_is_integer(request_span.timestamp)
-    assert.truthy(request_span.duration >= proxy_span.duration)
+
+    if request_span.duration and proxy_span.duration then
+      assert.truthy(request_span.duration >= proxy_span.duration)
+    end
 
     assert.equals(2, #request_span.annotations)
     local rann = annotations_to_hash(request_span.annotations)
@@ -83,7 +59,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
     assert_is_integer(rann["krf"])
     assert.truthy(rann["krs"] <= rann["krf"])
 
-    assert.same(ngx.null, request_span.localEndpoint)
+    assert.is_nil(request_span.localEndpoint)
 
     -- proxy_span
     assert.same("table", type(proxy_span))
@@ -96,7 +72,10 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
     assert.same("string", type(proxy_span.traceId))
     assert.truthy(proxy_span.traceId:match("^%x+$"))
     assert_is_integer(proxy_span.timestamp)
-    assert.truthy(proxy_span.duration >= 0)
+
+    if request_span.duration and proxy_span.duration then
+      assert.truthy(proxy_span.duration >= 0)
+    end
 
     assert.equals(6, #proxy_span.annotations)
     local pann = annotations_to_hash(proxy_span.annotations)
@@ -117,25 +96,6 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
 
 
   setup(function()
-    -- create a mock zipkin server
-    server = assert(http_server.listen {
-      host = "127.0.0.1",
-      port = 0,
-      onstream = function(_, stream)
-        local req_headers = assert(stream:get_headers())
-        local res_headers = new_headers()
-        res_headers:upsert(":status", "500")
-        res_headers:upsert("connection", "close")
-        assert(cb, "test has not set callback")
-        local body = cb(req_headers, res_headers, stream)
-        assert(stream:write_headers(res_headers, false))
-        assert(stream:write_chunk(body or "", true))
-      end,
-    })
-    assert(server:listen())
-    local _
-    _, zipkin_host, zipkin_port = server:localname()
-
     local bp = helpers.get_db_utils(strategy, { "services", "routes", "plugins" })
 
     -- enable zipkin plugin globally pointing to mock server
@@ -143,7 +103,7 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       name = "zipkin",
       config = {
         sample_ratio = 1,
-        http_endpoint = string.format("http://%s:%d/api/v2/spans", zipkin_host, zipkin_port),
+        http_endpoint = "http://127.0.0.1:9411/api/v2/spans",
       }
     })
 
@@ -170,198 +130,213 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
       nginx_conf = "spec/fixtures/custom_nginx.template",
     })
 
-    proxy_host = helpers.get_proxy_ip(false)
-    proxy_port = helpers.get_proxy_port(false)
+    proxy_client = helpers.proxy_client()
     proxy_client_grpc = helpers.proxy_client_grpc()
+    zipkin_client = helpers.http_client("127.0.0.1", 9411)
   end)
 
   teardown(function()
-    server:close()
     helpers.stop_kong()
   end)
 
   it("generates spans, tags and annotations for regular requests", function()
-    assert.truthy(with_server(function(_, _, stream)
-      local spans = cjson.decode((assert(stream:get_body_as_string())))
+    local trace_id = gen_trace_id()
 
-      assert.equals(3, #spans)
-      local balancer_span, proxy_span, request_span = spans[1], spans[2], spans[3]
-      -- common assertions for request_span and proxy_span
-      assert_span_invariants(request_span, proxy_span, "GET")
+    local r = assert(proxy_client:send {
+      method  = "GET",
+      path    = "/",
+      headers = {
+        ["x-b3-traceid"] = trace_id,
+        ["x-b3-sampled"] = "1",
+        host  = "mock-http-route",
+      },
+    })
+    assert.response(r).has.status(200)
 
-      -- specific assertions for request_span
-      local request_tags = request_span.tags
-      assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
-      request_tags["kong.node.id"] = nil
-      assert.same({
-        ["http.method"] = "GET",
-        ["http.path"] = "/",
-        ["http.status_code"] = "200", -- found (matches server status)
-        lc = "kong"
-      }, request_tags)
-      local peer_port = request_span.remoteEndpoint.port
-      assert_is_integer(peer_port)
-      assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
+    local spans
+    helpers.wait_until(function()
+      local res = assert(zipkin_client:get("/api/v2/trace/" .. trace_id))
+      spans = cjson.decode(assert.response(res).has.status(200))
+      return #spans == 3
+    end)
 
-      -- specific assertions for proxy_span
-      assert.same(proxy_span.tags["kong.route"], route.id)
-      assert.same(proxy_span.tags["peer.hostname"], "127.0.0.1")
+    local balancer_span, proxy_span, request_span = spans[1], spans[2], spans[3]
+    -- common assertions for request_span and proxy_span
+    assert_span_invariants(request_span, proxy_span, "get")
 
-      assert.same({ ipv4 = helpers.mock_upstream_host, port = helpers.mock_upstream_port },
-        proxy_span.remoteEndpoint)
+    -- specific assertions for request_span
+    local request_tags = request_span.tags
+    assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
+    request_tags["kong.node.id"] = nil
+    assert.same({
+      ["http.method"] = "GET",
+      ["http.path"] = "/",
+      ["http.status_code"] = "200", -- found (matches server status)
+      lc = "kong"
+    }, request_tags)
+    local peer_port = request_span.remoteEndpoint.port
+    assert.equals("number", type(peer_port))
+    assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
 
-      -- specific assertions for balancer_span
-      assert.equals(balancer_span.parentId, request_span.id)
-      assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
-      assert_is_integer(balancer_span.timestamp)
-      assert_is_integer(balancer_span.duration)
+    -- specific assertions for proxy_span
+    assert.same(proxy_span.tags["kong.route"], route.id)
+    assert.same(proxy_span.tags["peer.hostname"], "127.0.0.1")
 
-      assert.same({ ipv4 = helpers.mock_upstream_host, port = helpers.mock_upstream_port },
-        balancer_span.remoteEndpoint)
-      assert.equals(ngx.null, balancer_span.localEndpoint)
-      assert.same({
-        error = "false",
-        ["kong.balancer.try"] = "1",
-      }, balancer_span.tags)
-    end, function()
-      -- regular request which matches the existing route
-      local req = http_request.new_from_uri("http://mock-http-route/")
-      req.host = proxy_host
-      req.port = proxy_port
-      assert(req:go())
-    end))
+    assert.same({ ipv4 = helpers.mock_upstream_host, port = helpers.mock_upstream_port },
+    proxy_span.remoteEndpoint)
+
+    -- specific assertions for balancer_span
+    assert.equals(balancer_span.parentId, request_span.id)
+    assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
+    assert.equals("number", type(balancer_span.timestamp))
+
+    if balancer_span.duration then
+      assert.equals("number", type(balancer_span.duration))
+    end
+
+    assert.same({ ipv4 = helpers.mock_upstream_host, port = helpers.mock_upstream_port },
+    balancer_span.remoteEndpoint)
+    assert.is_nil(balancer_span.localEndpoint)
+    assert.same({
+      error = "false",
+      ["kong.balancer.try"] = "1",
+    }, balancer_span.tags)
   end)
 
   it("generates spans, tags and annotations for regular requests (#grpc)", function()
-    assert.truthy(with_server(function(_, _, stream)
-      local spans = cjson.decode((assert(stream:get_body_as_string())))
+    local trace_id = gen_trace_id()
 
-      --assert.equals(3, #spans)
-      local balancer_span, proxy_span, request_span = spans[1], spans[2], spans[3]
-      -- common assertions for request_span and proxy_span
-      assert_span_invariants(request_span, proxy_span, "POST")
+    local ok, resp = proxy_client_grpc({
+      service = "hello.HelloService.SayHello",
+      body = {
+        greeting = "world!"
+      },
+      opts = {
+        ["-H"] = "'x-b3-traceid: " .. trace_id .. "' -H 'x-b3-sampled: 1'",
+        ["-authority"] = "mock-grpc-route",
+      }
+    })
+    assert.truthy(ok)
+    assert.truthy(resp)
 
-      -- specific assertions for request_span
-      local request_tags = request_span.tags
-      assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
-      request_tags["kong.node.id"] = nil
-      assert.same({
-        ["http.method"] = "POST",
-        ["http.path"] = "/hello.HelloService/SayHello",
-        ["http.status_code"] = "200", -- found (matches server status)
-        lc = "kong"
-      }, request_tags)
-      local peer_port = request_span.remoteEndpoint.port
-      assert_is_integer(peer_port)
-      assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
+    local spans
+    helpers.wait_until(function()
+      local res = assert(zipkin_client:get("/api/v2/trace/" .. trace_id))
+      spans = cjson.decode(assert.response(res).has.status(200))
+      return #spans == 3
+    end)
 
-      -- specific assertions for proxy_span
-      assert.same(proxy_span.tags["kong.route"], grpc_route.id)
-      assert.same(proxy_span.tags["peer.hostname"], "localhost")
+    local balancer_span, proxy_span, request_span = spans[1], spans[2], spans[3]
+    -- common assertions for request_span and proxy_span
+    assert_span_invariants(request_span, proxy_span, "post")
 
-      assert.same({ ipv4 = "127.0.0.1", port = 15002 },
-        proxy_span.remoteEndpoint)
+    -- specific assertions for request_span
+    local request_tags = request_span.tags
+    assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
+    request_tags["kong.node.id"] = nil
+    assert.same({
+      ["http.method"] = "POST",
+      ["http.path"] = "/hello.HelloService/SayHello",
+      ["http.status_code"] = "200", -- found (matches server status)
+      lc = "kong"
+    }, request_tags)
+    local peer_port = request_span.remoteEndpoint.port
+    assert_is_integer(peer_port)
+    assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
 
-      -- specific assertions for balancer_span
-      assert.equals(balancer_span.parentId, request_span.id)
-      assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
-      assert_is_integer(balancer_span.timestamp)
+    -- specific assertions for proxy_span
+    assert.same(proxy_span.tags["kong.route"], grpc_route.id)
+    assert.same(proxy_span.tags["peer.hostname"], "localhost")
+
+    assert.same({ ipv4 = "127.0.0.1", port = 15002 },
+    proxy_span.remoteEndpoint)
+
+    -- specific assertions for balancer_span
+    assert.equals(balancer_span.parentId, request_span.id)
+    assert.equals(request_span.name .. " (balancer try 1)", balancer_span.name)
+    assert_is_integer(balancer_span.timestamp)
+
+    if balancer_span.duration then
       assert_is_integer(balancer_span.duration)
+    end
 
-      assert.same({ ipv4 = "127.0.0.1", port = 15002 },
-        balancer_span.remoteEndpoint)
-      assert.equals(ngx.null, balancer_span.localEndpoint)
-      assert.same({
-        error = "false",
-        ["kong.balancer.try"] = "1",
-      }, balancer_span.tags)
-    end, function()
-      -- Making the request
-      local ok, resp = proxy_client_grpc({
-        service = "hello.HelloService.SayHello",
-        body = {
-          greeting = "world!"
-        },
-        opts = {
-          ["-authority"] = "mock-grpc-route",
-        }
-      })
-      assert.truthy(ok)
-      assert.truthy(resp)
-    end))
+    assert.same({ ipv4 = "127.0.0.1", port = 15002 },
+    balancer_span.remoteEndpoint)
+    assert.is_nil(balancer_span.localEndpoint)
+    assert.same({
+      error = "false",
+      ["kong.balancer.try"] = "1",
+    }, balancer_span.tags)
   end)
 
   it("generates spans, tags and annotations for non-matched requests", function()
-    assert.truthy(with_server(function(_, _, stream)
-      local spans = cjson.decode((assert(stream:get_body_as_string())))
-      assert.equals(2, #spans)
-      local proxy_span, request_span = spans[1], spans[2]
-      -- common assertions for request_span and proxy_span
-      assert_span_invariants(request_span, proxy_span, "GET")
+    local trace_id = gen_trace_id()
 
-      -- specific assertions for request_span
-      local request_tags = request_span.tags
-      assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
-      request_tags["kong.node.id"] = nil
-      assert.same({
-        ["http.method"] = "GET",
-        ["http.path"] = "/",
-        ["http.status_code"] = "404", -- note that this was "not found"
-        lc = "kong"
-      }, request_tags)
-      local peer_port = request_span.remoteEndpoint.port
-      assert_is_integer(peer_port)
-      assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
+    local r = assert(proxy_client:send {
+      method  = "GET",
+      path    = "/foobar",
+      headers = {
+        ["x-b3-traceid"] = trace_id,
+        ["x-b3-sampled"] = "1",
+      },
+    })
+    assert.response(r).has.status(404)
 
-      -- specific assertions for proxy_span
-      assert.is_nil(proxy_span.tags)
+    local spans
+    helpers.wait_until(function()
+      local res = assert(zipkin_client:get("/api/v2/trace/" .. trace_id))
+      spans = cjson.decode(assert.response(res).has.status(200))
+      return #spans == 2
+    end)
 
-      assert.equals(ngx.null, proxy_span.remoteEndpoint)
-      assert.equals(ngx.null, proxy_span.localEndpoint)
-    end, function()
-      -- This request reaches the proxy, but doesn't match any route.
-      -- The plugin runs in "error mode": access phase doesn't run, but others, like header_filter, do run
-      local uri = string.format("http://%s:%d/", proxy_host, proxy_port)
-      local req = http_request.new_from_uri(uri)
-      assert(req:go())
-    end))
+    local proxy_span, request_span = spans[1], spans[2]
+
+    -- common assertions for request_span and proxy_span
+    assert_span_invariants(request_span, proxy_span, "get")
+
+    -- specific assertions for request_span
+    local request_tags = request_span.tags
+    assert.truthy(request_tags["kong.node.id"]:match("^[%x-]+$"))
+    request_tags["kong.node.id"] = nil
+    assert.same({
+      ["http.method"] = "GET",
+      ["http.path"] = "/foobar",
+      ["http.status_code"] = "404", -- note that this was "not found"
+      lc = "kong"
+    }, request_tags)
+    local peer_port = request_span.remoteEndpoint.port
+    assert_is_integer(peer_port)
+    assert.same({ ipv4 = "127.0.0.1", port = peer_port }, request_span.remoteEndpoint)
+
+    -- specific assertions for proxy_span
+    assert.is_nil(proxy_span.tags)
+    assert.is_nil(proxy_span.remoteEndpoint)
+    assert.is_nil(proxy_span.localEndpoint)
   end)
-
-  it("propagates b3 headers on routed request", function()
-    local trace_id = "1234567890abcdef"
-    assert.truthy(with_server(function(_, _, stream)
-      local spans = cjson.decode((assert(stream:get_body_as_string())))
-      for _, v in ipairs(spans) do
-        assert.same(trace_id, v.traceId)
-      end
-    end, function()
-      -- regular request, with extra headers
-      local req = http_request.new_from_uri("http://mock-http-route/")
-      req.host = proxy_host
-      req.port = proxy_port
-      req.headers:upsert("x-b3-traceid", trace_id)
-      req.headers:upsert("x-b3-sampled", "1")
-      assert(req:go())
-    end))
-  end)
-
-  -- TODO add grpc counterpart of above test case
 
   it("propagates b3 headers for non-matched requests", function()
-    local trace_id = "1234567890abcdef"
-    assert.truthy(with_server(function(_, _, stream)
-      local spans = cjson.decode((assert(stream:get_body_as_string())))
-      for _, v in ipairs(spans) do
-        assert.same(trace_id, v.traceId)
-      end
-    end, function()
-      -- This request reaches the proxy, but doesn't match any route. The trace_id should be respected here too
-      local uri = string.format("http://%s:%d/", proxy_host, proxy_port)
-      local req = http_request.new_from_uri(uri)
-      req.headers:upsert("x-b3-traceid", trace_id)
-      req.headers:upsert("x-b3-sampled", "1")
-      assert(req:go())
-    end))
+    local trace_id = gen_trace_id()
+
+    local r = assert(proxy_client:send {
+      method  = "GET",
+      path    = "/foobar",
+      headers = {
+        ["x-b3-traceid"] = trace_id,
+        ["x-b3-sampled"] = "1",
+      },
+    })
+    assert.response(r).has.status(404)
+
+    local spans
+    helpers.wait_until(function()
+      local res = assert(zipkin_client:get("/api/v2/trace/" .. trace_id))
+      spans = cjson.decode(assert.response(res).has.status(200))
+      return #spans == 2
+    end)
+
+    for _, v in ipairs(spans) do
+      assert.same(trace_id, v.traceId)
+    end
   end)
 end)
 end

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -79,9 +79,9 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
 
     assert.equals(2, #request_span.annotations)
     local rann = annotations_to_hash(request_span.annotations)
-    assert_is_integer(rann["kong.rewrite.start"])
-    assert_is_integer(rann["kong.rewrite.finish"])
-    assert.truthy(rann["kong.rewrite.start"] <= rann["kong.rewrite.finish"])
+    assert_is_integer(rann["krs"])
+    assert_is_integer(rann["krf"])
+    assert.truthy(rann["krs"] <= rann["krf"])
 
     assert.same(ngx.null, request_span.localEndpoint)
 
@@ -101,18 +101,18 @@ describe("integration tests with mock zipkin server [#" .. strategy .. "]", func
     assert.equals(6, #proxy_span.annotations)
     local pann = annotations_to_hash(proxy_span.annotations)
 
-    assert_is_integer(pann["kong.access.start"])
-    assert_is_integer(pann["kong.access.finish"])
-    assert_is_integer(pann["kong.header_filter.start"])
-    assert_is_integer(pann["kong.header_filter.finish"])
-    assert_is_integer(pann["kong.body_filter.start"])
-    assert_is_integer(pann["kong.body_filter.finish"])
+    assert_is_integer(pann["kas"])
+    assert_is_integer(pann["kaf"])
+    assert_is_integer(pann["khs"])
+    assert_is_integer(pann["khf"])
+    assert_is_integer(pann["kbs"])
+    assert_is_integer(pann["kbf"])
 
-    assert.truthy(pann["kong.access.start"]        <= pann["kong.access.finish"])
-    assert.truthy(pann["kong.header_filter.start"] <= pann["kong.header_filter.finish"])
-    assert.truthy(pann["kong.body_filter.start"]   <= pann["kong.body_filter.finish"])
+    assert.truthy(pann["kas"] <= pann["kaf"])
+    assert.truthy(pann["khs"] <= pann["khf"])
+    assert.truthy(pann["kbs"] <= pann["kbf"])
 
-    assert.truthy(pann["kong.header_filter.start"] <= pann["kong.body_filter.start"])
+    assert.truthy(pann["khs"] <= pann["kbs"])
   end
 
 


### PR DESCRIPTION
This PR includes several changes:
* It makes the timestamps integers instead of floats, in order to satisfy Zipkin's requirements on timestamps.
* It changes the annotations format (`event` key was renamed to `value`)
* The annotation values were shortened (we use `kas` instead of `kong.access.start`, for example).

This PR also includes changes in the test suite which run a proper Zipkin server instead of a mocked one.