### PR TITLE
feat(reporter) local & remote Endpoint improvements

### DIFF
--- a/kong/plugins/zipkin/opentracing.lua
+++ b/kong/plugins/zipkin/opentracing.lua
@@ -239,8 +239,6 @@ function OpenTracingHandler:log(conf)
         span:set_tag("error", true)
         span:set_tag("kong.balancer.state", try.state)
         span:set_tag("http.status_code", try.code)
-      else
-        span:set_tag("error", false)
       end
       span:finish((try.balancer_start + try.balancer_latency) / 1000)
     end

--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -198,7 +198,6 @@ describe("integration tests with zipkin server [#" .. strategy .. "]", function(
     balancer_span.remoteEndpoint)
     assert.is_nil(balancer_span.localEndpoint)
     assert.same({
-      error = "false",
       ["kong.balancer.try"] = "1",
     }, balancer_span.tags)
   end)
@@ -264,7 +263,6 @@ describe("integration tests with zipkin server [#" .. strategy .. "]", function(
     balancer_span.remoteEndpoint)
     assert.is_nil(balancer_span.localEndpoint)
     assert.same({
-      error = "false",
       ["kong.balancer.try"] = "1",
     }, balancer_span.tags)
   end)


### PR DESCRIPTION
Fixes #55

In all the Spans generated by kong:

* The `localEndpoint` is `{ serviceName = "kong" }` in all spans.

The `remoteEndpoint` has changed as follows:

* On the request (root) span, it remains as before:
  * `remoteEndpoint.ipv4/v6` and `remoteEndpoint.port` point to
the consumer's forwarded ip and port

* On each balancer attempt span:
  * If a Kong Service was found when proxying, and that Service has a
`name`, then `remoteEndpoint.serviceName` will be the Service Name.
  * `remoteEndpoint.ipv4/v6` and `remoteEndpoint.port` will point to
the ip+port combination used on the span

* On the proxy span:
  * If a Kong Service was found when proxying, and that Service has a
`name`, then `remoteEndpoint.serviceName` will be the Service Name.
  * `remoteEndpoint.ipv4/v6` and `remoteEndpoint.port` will point to
the first successful combination of balancer attempts.

This PR also fixes a small issue where non-erroneous proxy spans appeared red on the UI because they the tag `error` set to `false`.