### PR TITLE
Add support for W3C Trace Context

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -139,8 +139,8 @@ if subsystem == "http" then
 
     -- Set the W3C Trace Context header
     -- TODO: Should W3C traceparent header be set even it wasn't on the incoming request?
-    -- TODO: Is .. concatenation performant?
-    set_header("Traceparent", "00-".. to_hex(proxy_span.trace_id) .. "-" .. to_hex(proxy_span.span_id) .. "-" .. tostring(proxy_span.should_sample and "01" or "00"))
+    set_header("traceparent", "00-".. to_hex(proxy_span.trace_id) .. "-" .. to_hex(proxy_span.span_id) .. "-" ..
+      tostring(proxy_span.should_sample and "01" or "00"))
 
     -- TODO: Should B3 headers be set even if they weren't on the incoming request?
     -- We want to remove headers if already present

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -136,6 +136,13 @@ if subsystem == "http" then
     -- Want to send headers to upstream
     local proxy_span = zipkin.proxy_span
     local set_header = kong.service.request.set_header
+
+    -- Set the W3C Trace Context header
+    -- TODO: Should W3C traceparent header be set even it wasn't on the incoming request?
+    -- TODO: Is .. concatenation performant?
+    set_header("Traceparent", "00-".. to_hex(proxy_span.trace_id) .. "-" .. to_hex(proxy_span.span_id) .. "-" .. tostring(proxy_span.should_sample and "01" or "00"))
+
+    -- TODO: Should B3 headers be set even if they weren't on the incoming request?
     -- We want to remove headers if already present
     set_header("x-b3-traceid", to_hex(proxy_span.trace_id))
     set_header("x-b3-spanid", to_hex(proxy_span.span_id))


### PR DESCRIPTION
Accepts W3C Trace Context header and prioritizes the W3C Trace Context when present.

Emits W3C Trace Context header whether it was present on the incoming request or not. Would like feedback on whether this behavior should be configurable.