### PR TITLE
make http_endpoint optional

### DIFF
--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -101,6 +101,10 @@ function zipkin_reporter_methods:flush()
   self.pending_spans = {}
   self.pending_spans_n = 0
 
+  if self.http_endpoint == nil or self.http_endpoint == '' then
+    return true
+  end
+
   local httpc = resty_http.new()
   local res, err = httpc:request_uri(self.http_endpoint, {
     method = "POST",

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -46,7 +46,7 @@ return {
     { config = {
         type = "record",
         fields = {
-          { http_endpoint = typedefs.url{ required = true } },
+          { http_endpoint = typedefs.url{ required = false, default = nil } },
           { sample_ratio = { type = "number",
                              default = 0.001,
                              between = { 0, 1 } } },


### PR DESCRIPTION
Hi,

This is a PR to make it possible to use the Zipkin plugin to propagate the trace context via Kong without sending the actual trace data to a remote Zipkin server. The use case for this is that we do not use the Zipkin UI to visualize traces - however we are still interested to correlate requests via trace information which we collect via log files. By making the `http_endpoint` configuration optional it makes it possible for us to use the out-of-the-box functionality of the plugin for the propagation without having to set up additional infrastructure to handle the collection of the actual trace data.