### PR TITLE
fix(*) create baggage items in child spans

### DIFF
--- a/kong/plugins/zipkin/span.lua
+++ b/kong/plugins/zipkin/span.lua
@@ -75,7 +75,6 @@ function span_methods:new_child(kind, name, start_timestamp_mu)
     self.trace_id,
     generate_span_id(),
     self.span_id,
-    self.sample_ratio,
     self.baggage
   )
 end


### PR DESCRIPTION
in the `new_child` span methods we added an additional argument by mistake - `sample_ratio` for the span initializer, which overrides the baggage argument. this fix suppose to pass the correct argument to this method