### PR TITLE
fix: balancer_latency is nil upon failure

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -22,7 +22,6 @@ local math_random        = math.random
 local ngx_req_start_time = ngx.req.start_time
 local ngx_now            = ngx.now
 
-
 -- ngx.now in microseconds
 local function ngx_now_mu()
   return ngx_now() * 1000000
@@ -322,7 +321,11 @@ function ZipkinLogHandler:log(conf) -- luacheck: ignore 212
 
       tag_with_service_and_route(span)
 
-      span:finish((try.balancer_start + try.balancer_latency) * 1000)
+      if try.balancer_latency ~= nil then
+        span:finish((try.balancer_start + try.balancer_latency) * 1000)
+      else
+        span:finish(now_mu)
+      end
       reporter:report(span)
     end
     proxy_span:set_tag("peer.hostname", balancer_data.hostname) -- could be nil

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -22,6 +22,7 @@ local math_random        = math.random
 local ngx_req_start_time = ngx.req.start_time
 local ngx_now            = ngx.now
 
+
 -- ngx.now in microseconds
 local function ngx_now_mu()
   return ngx_now() * 1000000


### PR DESCRIPTION
It seems related to the fact that when the load-balancer fails, the latency information is missing.

https://github.com/Kong/kong/issues/6820



```
[error] 87#0: *5293734 failed to run log_by_lua*:
    /usr/local/share/lua/5.1/kong/plugins/zipkin/handler.lua:332:
    attempt to perform arithmetic on field 'balancer_latency' (a nil value) stack traceback:
 	/usr/local/share/lua/5.1/kong/plugins/zipkin/handler.lua:332: in function </usr/local/share/lua/5.1/kong/plugins/zipkin/handler.lua:266>
 	/usr/local/share/lua/5.1/kong/init.lua:265: in function 'execute_plugins_iterator'
 	/usr/local/share/lua/5.1/kong/init.lua:1286: in function 'log'
 	log_by_lua(nginx-kong.conf:102):2: in main chunk while logging request, client: ...
```