### PR TITLE
fix(handler) don't share context between several zipkin plugins

### DIFF
--- a/spec/zipkin_spec.lua
+++ b/spec/zipkin_spec.lua
@@ -94,6 +94,9 @@ local function assert_span_invariants(request_span, proxy_span, expected_name, t
     assert.truthy(request_span.duration >= proxy_span.duration)
   end
 
+  if #request_span.annotations == 1 then
+    error(require("inspect")(request_span))
+  end
   assert.equals(2, #request_span.annotations)
   local rann = annotations_to_hash(request_span.annotations)
   assert_valid_timestamp(rann["krs"], start_s)
@@ -136,7 +139,80 @@ local function assert_span_invariants(request_span, proxy_span, expected_name, t
 end
 
 
+for _, strategy in helpers.each_strategy() do
+  describe("plugin configuration", function()
+    local proxy_client, zipkin_client, service
 
+    setup(function()
+      local bp = helpers.get_db_utils(strategy, { "services", "routes", "plugins" })
+
+      service = bp.services:insert {
+        name = string.lower("http-" .. utils.random_string()),
+      }
+
+      -- kong (http) mock upstream
+      bp.routes:insert({
+        name = string.lower("route-" .. utils.random_string()),
+        service = service,
+        hosts = { "http-route" },
+        preserve_host = true,
+      })
+
+      -- enable zipkin plugin globally, with sample_ratio = 1
+      bp.plugins:insert({
+        name = "zipkin",
+        config = {
+          sample_ratio = 0,
+          http_endpoint = fmt("http://%s:%d/api/v2/spans", ZIPKIN_HOST, ZIPKIN_PORT),
+          default_header_type = "b3-single",
+        }
+      })
+
+      -- enable zipkin on the service, with sample_ratio = 1
+      -- this should generate traces, even if there is another plugin with sample_ratio = 0
+      bp.plugins:insert({
+        name = "zipkin",
+        service = { id = service.id },
+        config = {
+          sample_ratio = 1,
+          http_endpoint = fmt("http://%s:%d/api/v2/spans", ZIPKIN_HOST, ZIPKIN_PORT),
+          default_header_type = "b3-single",
+        }
+      })
+
+      helpers.start_kong({
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        stream_listen = helpers.get_proxy_ip(false) .. ":19000",
+      })
+
+      proxy_client = helpers.proxy_client()
+      zipkin_client = helpers.http_client(ZIPKIN_HOST, ZIPKIN_PORT)
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    it("#generates traces when several plugins exist and one of them has sample_ratio = 0 but not the other", function()
+      local start_s = ngx.now()
+
+      local r = proxy_client:get("/", {
+        headers = {
+          ["x-b3-sampled"] = "1",
+          host  = "http-route",
+          ["zipkin-tags"] = "foo=bar; baz=qux"
+        },
+      })
+      assert.response(r).has.status(200)
+
+      local _, proxy_span, request_span =
+        wait_for_spans(zipkin_client, 3, service.name)
+      -- common assertions for request_span and proxy_span
+      assert_span_invariants(request_span, proxy_span, "get", 16 * 2, start_s)
+    end)
+  end)
+end
 
 
 for _, strategy in helpers.each_strategy() do
@@ -220,6 +296,7 @@ describe("http integration tests with zipkin server [#"
     proxy_client_grpc = helpers.proxy_client_grpc()
     zipkin_client = helpers.http_client(ZIPKIN_HOST, ZIPKIN_PORT)
   end)
+
 
   teardown(function()
     helpers.stop_kong()
@@ -794,7 +871,7 @@ describe("http integration tests with zipkin server [#"
     end)
 
     it("works on non-matched requests", function()
-      local trace_id = gen_trace_id(8) 
+      local trace_id = gen_trace_id(8)
       local span_id = gen_span_id()
 
       local r = proxy_client:get("/foobar", {


### PR DESCRIPTION
Fixes #106

The problem fixed on this change is that this plugin was using `ngx.ctx` exclusively, **including for creating a pseudo-global variable in `ngx.ctx.zipkin`** (for the duration of each request)

This meant that a single instance of the Zipkin plugin would work just fine, but several of them (i.e. one global plus one per Service) would collide with each other - the second one would override the first one.

The change consists on using `kong.ctx.plugin` to hold the `zipkin` table, instead of `ngx.ctx`.

Notice that `ngx.ctx` is still used extensively since the plugin reads and uses variable stored there by Kong.

A new independent test which uses two Zipkin plugins has been added.