### PR TITLE
feat(span-name): add http.path to span name

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -116,7 +116,6 @@ if subsystem == "http" then
     local header_type, trace_id, span_id, parent_id, should_sample, baggage =
       tracing_headers.parse(req_headers)
     local method = req.get_method()
-    local path = req.get_path()
 
     if should_sample == nil then
       should_sample = math_random() < conf.sample_ratio
@@ -125,10 +124,16 @@ if subsystem == "http" then
     if trace_id == nil then
       trace_id = rand_bytes(conf.traceid_byte_count)
     end
+    
+    local span_format = method
+    local path = req.get_path()
+    if conf.span_display_path == true then
+      span_format = method .. ' ' .. path
+    end  
 
     local request_span = new_span(
       "SERVER",
-      method .. ' ' .. path,
+      span_format,
       ngx_req_start_time_mu(),
       should_sample,
       trace_id,

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -116,6 +116,7 @@ if subsystem == "http" then
     local header_type, trace_id, span_id, parent_id, should_sample, baggage =
       tracing_headers.parse(req_headers)
     local method = req.get_method()
+    local path = req.get_path()
 
     if should_sample == nil then
       should_sample = math_random() < conf.sample_ratio
@@ -127,7 +128,7 @@ if subsystem == "http" then
 
     local request_span = new_span(
       "SERVER",
-      method,
+      method .. ' ' .. path,
       ngx_req_start_time_mu(),
       should_sample,
       trace_id,
@@ -140,7 +141,7 @@ if subsystem == "http" then
 
     request_span:set_tag("lc", "kong")
     request_span:set_tag("http.method", method)
-    request_span:set_tag("http.path", req.get_path())
+    request_span:set_tag("http.path", path)
 
     local static_tags = conf.static_tags
     if type(static_tags) == "table" then

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -60,6 +60,7 @@ return {
           { tags_header = { type = "string", required = true, default = "Zipkin-Tags" } },
           { static_tags = { type = "array", elements = static_tag,
                             custom_validator = validate_static_tags } },
+          { span_display_path = { type = "boolean", default = false } },
         },
     }, },
   },


### PR DESCRIPTION
## Proposed Changes
To display trace as "Kong, http.method http.path" by adding http.path to the span name.

## Reason
The span name is displayed as "http.method" in the main dashboard.
It is difficult to distinguish traces at first glance.
By adding http.path to the span name, the trace would be displayed as "Kong, http.method http.path" 