### PR TITLE
feat: ignore existing trace

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -113,15 +113,8 @@ if subsystem == "http" then
 
     local req_headers = req.get_headers()
 
-    local header_type = conf.default_header_type
-    local trace_id, span_id, parent_id, should_sample, baggage
-
-    -- If header_type is set to `ignore`, then the default_header_type will
-    -- be used to initiate a new trace.
-    if conf.header_type ~= "ignore" then
-      header_type, trace_id, span_id, parent_id, should_sample, baggage =
-        tracing_headers.parse(req.get_headers())
-    end
+    local header_type, trace_id, span_id, parent_id, should_sample, baggage =
+      tracing_headers.parse(req_headers, conf.header_type)
 
     local method = req.get_method()
 

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -113,8 +113,16 @@ if subsystem == "http" then
 
     local req_headers = req.get_headers()
 
-    local header_type, trace_id, span_id, parent_id, should_sample, baggage =
-      tracing_headers.parse(req_headers)
+    local header_type = conf.default_header_type
+    local trace_id, span_id, parent_id, should_sample, baggage
+
+    -- If header_type is set to `ignore`, then the default_header_type will
+    -- be used to initiate a new trace.
+    if conf.header_type ~= "ignore" then
+      header_type, trace_id, span_id, parent_id, should_sample, baggage =
+        tracing_headers.parse(req.get_headers())
+    end
+
     local method = req.get_method()
 
     if should_sample == nil then

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -54,7 +54,7 @@ return {
           { include_credential = { type = "boolean", required = true, default = true } },
           { traceid_byte_count = { type = "integer", required = true, default = 16, one_of = { 8, 16 } } },
           { header_type = { type = "string", required = true, default = "preserve",
-                            one_of = { "preserve", "b3", "b3-single", "w3c", "jaeger", "ot" } } },
+                            one_of = { "preserve", "ignore", "b3", "b3-single", "w3c", "jaeger", "ot" } } },
           { default_header_type = { type = "string", required = true, default = "b3",
                                     one_of = { "b3", "b3-single", "w3c", "jaeger", "ot" } } },
           { tags_header = { type = "string", required = true, default = "Zipkin-Tags" } },

--- a/kong/plugins/zipkin/tracing_headers.lua
+++ b/kong/plugins/zipkin/tracing_headers.lua
@@ -364,7 +364,11 @@ local function find_header_type(headers)
 end
 
 
-local function parse(headers)
+local function parse(headers, conf_header_type)
+  if conf_header_type == "ignore" then
+    return nil
+  end
+
   -- Check for B3 headers first
   local header_type, composed_header = find_header_type(headers)
   local trace_id, span_id, parent_id, should_sample

--- a/kong/plugins/zipkin/tracing_headers.lua
+++ b/kong/plugins/zipkin/tracing_headers.lua
@@ -401,7 +401,10 @@ end
 local function set(conf_header_type, found_header_type, proxy_span, conf_default_header_type)
   local set_header = kong.service.request.set_header
 
+  -- If conf_header_type is set to `preserve`, default_header_type is ignored when found is set.
+  -- if conf_headre_type is set to `ignore`, found_header_type is not set, thus default_header_type is used.
   if conf_header_type ~= "preserve" and
+     conf_header_type ~= "ignore" and
      found_header_type ~= nil and
      conf_header_type ~= found_header_type
   then

--- a/kong/plugins/zipkin/tracing_headers.lua
+++ b/kong/plugins/zipkin/tracing_headers.lua
@@ -401,8 +401,8 @@ end
 local function set(conf_header_type, found_header_type, proxy_span, conf_default_header_type)
   local set_header = kong.service.request.set_header
 
-  -- If conf_header_type is set to `preserve`, default_header_type is ignored when found is set.
-  -- if conf_headre_type is set to `ignore`, found_header_type is not set, thus default_header_type is used.
+  -- If conf_header_type is set to `preserve`, found_header_type is used over default_header_type;
+  -- if conf_header_type is set to `ignore`, found_header_type is not set, thus default_header_type is used.
   if conf_header_type ~= "preserve" and
      conf_header_type ~= "ignore" and
      found_header_type ~= nil and

--- a/spec/tracing_headers_spec.lua
+++ b/spec/tracing_headers_spec.lua
@@ -47,6 +47,13 @@ describe("tracing_headers.parse", function()
       warn:revert()
     end)
 
+    it("does not parse headers with ignore type", function()
+      local b3 = fmt("%s-%s-%s-%s", trace_id, span_id, "1", parent_id)
+      local t = { parse({ tracestate = "b3=" .. b3 }, "ignore") }
+      assert.spy(warn).not_called()
+      assert.same({}, t)
+    end)
+
     it("1-char", function()
       local t  = { parse({ b3 = "1" }) }
       assert.same({ "b3-single", nil, nil, nil, true }, t)


### PR DESCRIPTION
This is a small change to @greut's #99. It moves the ignoring logic to the `tracing_headers.parse`  function, in order to test it easily on the tracing_headers spec.